### PR TITLE
Added mongoose document instantiation support...

### DIFF
--- a/lib/mongoose-memcached.js
+++ b/lib/mongoose-memcached.js
@@ -4,7 +4,8 @@
  */
 var Memcached = require('memcached'),
     NodeStream = require('stream'),
-    helpers = require('mongoose/lib/queryhelpers');
+    helpers = require('mongoose/lib/queryhelpers'),
+    Promise = require('mpromise');
 
 /**
  * sets the function to generate the key
@@ -105,8 +106,93 @@ module.exports = function mongooseMemcached(mongoose, options) {
         self._dataCached = false;
         return exec.call(self, e);
       } else if (data) {
-        self._dataCached = true;
-        return cb(e, data);
+        var pop, opts = self._mongooseOptions;
+        if (opts.populate) { pop = helpers.preparePopulationOptionsMQ(self, opts); }
+          
+        if (Array.isArray(data)) {
+            var arr = [];
+            var createAndEmit = function (promise, doc) {
+                var instance = helpers.createModel(self.model, doc, self._fields);
+                instance.init(doc, function (err) {
+                  if (err) { return promise.reject(err); }
+                  promise.fulfill(instance);
+                });
+            };
+            // instanciation promise generator
+            var instanciate = function (doc) {
+                // create promise
+                var promise = new Promise();
+                promise.onFulfill(function (arg) {
+                    arr.push(arg);
+                });
+                // Check population
+                if (!pop) {
+                  if (opts.lean) {
+                    promise.fulfill(doc);
+                  } else {
+                    createAndEmit(promise, doc);
+                  }
+                  return promise;
+                }
+                // Populate document
+                self.model.populate(doc, pop, function (err, doc) {
+                  if (err) { return promise.reject(err); }
+                    return true === opts.lean
+                      ? promise.fulfill(doc)
+                      : createAndEmit(promise, doc);
+                });                
+                return promise;
+            };
+            // chaining instanciation promises
+            var initialPromise, returnPromise = initialPromise = new Promise(), i, len;
+            for (i = 0, len = data.length; i < len; i += 1) {
+              returnPromise = returnPromise.chain(instanciate(data[i]));
+            }
+            // on chain resolve
+            returnPromise.onResolve(function (err) {
+              if (err) {
+                self._dataCached = false;
+                return cb(err);
+              }
+              self._dataCached = true;
+              cb(null, arr);
+            });
+            // start chain
+            initialPromise.fulfill();
+        } else {
+            var pop, opts = self._mongooseOptions;
+            if (opts.populate) { pop = helpers.preparePopulationOptionsMQ(self, opts); }
+            
+            var createAndEmit = function (doc) {
+                var instance = helpers.createModel(self.model, doc, self._fields);
+                instance.init(doc, function (err) {
+                  if (err) {
+                    self._dataCached = false;
+                    return cb(err);
+                  }
+                  self._dataCached = true;
+                  cb(null, instance);
+                });
+            };
+            
+            // Check population
+            if (!pop) {
+              if (opts.lean) {
+                cb(null, data);
+              } else {
+                createAndEmit(data);
+              }
+              return this;
+            }
+            // Populate document
+            self.model.populate(doc, pop, function (err, doc) {
+              if (err) { return promise.reject(err); }
+                return true === opts.lean
+                  ? cb(null, doc)
+                  : createAndEmit(doc);
+            });                
+        }
+        return this;
       }
 
       // if it does not exist, set the data after execution finished

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "mongoose": "3.8.*",
-    "memcached": "*"
+    "memcached": "*",
+    "mpromise": "0.5.*"
   },
   "devDependencies": {
     "expect.js": "*",

--- a/test/test.js
+++ b/test/test.js
@@ -120,6 +120,7 @@ describe('mongoose-memcached', function() {
               if (err) {
                 return done(err);
               }
+              var docsOrg = docs.map(function (doc) { return doc.toObject(); });
               query = People.find({}).cache().exec(function (err, docs) {
                 if (err) {
                   return done(err);
@@ -128,6 +129,8 @@ describe('mongoose-memcached', function() {
                   time = Date.now() - time;
                   expect(docs).to.be.ok();
                   expect(query.isFromCache).to.be(true);
+                  expect(docs[0].save).to.be.a('function');
+                  expect(docsOrg).to.eql(docs.map(function (doc) { return doc.toObject(); }));
                   done();
                 }
               });
@@ -214,6 +217,7 @@ describe('mongoose-memcached', function() {
             expect(query.isFromCache).to.be(true);
             // length should be 10 instead of 15 because these are cached docs
             expect(docs).to.have.length(10);
+            expect(docs[0].save).to.be(undefined);
             done();
           }
         });


### PR DESCRIPTION
...with population, lean, and population + lean support.

As mongoose-memcached works now the objects returned from a cached query are simple data objects with no mongoose document functionality, such as `save`, `delete`, `update`, and so on. This patch changes that and gives back, by default, mongoose document instantiated cached data, with support for lean, populate and a combination of both.
Note: This is written to support `findOne` query as well.
