### PR TITLE
Replaced exec.call(self, e) with exec.call(self, cb)

### DIFF
--- a/lib/mongoose-memcached.js
+++ b/lib/mongoose-memcached.js
@@ -104,7 +104,7 @@ module.exports = function mongooseMemcached(mongoose, options) {
       // if it does exist, return the data
       if(e) {
         self._dataCached = false;
-        return exec.call(self, e);
+        return exec.call(self, cb);
       } else if (data) {
         var pop, opts = self._mongooseOptions;
         if (opts.populate) { pop = helpers.preparePopulationOptionsMQ(self, opts); }


### PR DESCRIPTION
exec.call takes a callback as the second argument, not the error.

Fixes #8
